### PR TITLE
Fix log probability computation

### DIFF
--- a/models/common.py
+++ b/models/common.py
@@ -12,13 +12,16 @@ def reparameterize_gaussian(mean, logvar):
 def gaussian_entropy(logvar):
     const = 0.5 * float(logvar.size(1)) * (1. + np.log(np.pi * 2))
     ent = 0.5 * logvar.sum(dim=1, keepdim=False) + const
+    
+    
     return ent
 
 
 def standard_normal_logprob(z):
-    dim = z.size(-1)
-    log_z = -0.5 * dim * np.log(2 * np.pi)
-    return log_z - z.pow(2) / 2
+    # dim = z.size(-1)
+    # log_z = -0.5 * dim * np.log(2 * np.pi)
+    # return log_z - z.pow(2) / 2
+    return -0.5 * (z.pow(2).sum(dim=1) + z.size(1) * np.log(2 * np.pi))
 
 
 def truncated_normal_(tensor, mean=0, std=1, trunc_std=2):

--- a/models/vae_gaussian.py
+++ b/models/vae_gaussian.py
@@ -30,7 +30,8 @@ class GaussianVAE(Module):
         batch_size, _, _ = x.size()
         z_mu, z_sigma = self.encoder(x)
         z = reparameterize_gaussian(mean=z_mu, logvar=z_sigma)  # (B, F)
-        log_pz = standard_normal_logprob(z).sum(dim=1)  # (B, ), Independence assumption
+        #log_pz = standard_normal_logprob(z).sum(dim=1)  # (B, ), Independence assumption
+        log_pz = standard_normal_logprob(z)
         entropy = gaussian_entropy(logvar=z_sigma)      # (B, )
         loss_prior = (- log_pz - entropy).mean()
 
@@ -42,6 +43,7 @@ class GaussianVAE(Module):
             writer.add_scalar('train/loss_entropy', -entropy.mean(), it)
             writer.add_scalar('train/loss_prior', -log_pz.mean(), it)
             writer.add_scalar('train/loss_recons', loss_recons, it)
+            writer.add_scalar('train/kl_loss', loss_prior, it)
 
         return loss
 


### PR DESCRIPTION
This is the math fix in the loss function discussed during summer. 

The old loss function had a dimension mismatch and was compounding an element in the loss function, causing the loss values to be in the 60s. This fix handles the dimension mismatch and removes the redundant .sum(dim=1) in GaussianVAE to avoid double-summing. Also adds KL loss to tensorboard logging.

TLDR: Math fix to drop loss values from 60s to <1.